### PR TITLE
add ability to force specific status for migration

### DIFF
--- a/flask-backend/src/process_match_entities.py
+++ b/flask-backend/src/process_match_entities.py
@@ -803,16 +803,19 @@ class EntitiesDumpJSON:
         type = entity['type']
         entity_id = entity['entityId']
         
+        # Clean unused entity properties, some exceptions for Hosts (we want to display these jsons) 
         if('fromRelationships' in entity):
             for key in entity['fromRelationships'].keys():
                 entity['fromRelationships'][key] = []
         if('toRelationships' in entity):
             for key in entity['toRelationships'].keys():
-                if(key != "isSiteOf"):
+                if(key != "isSiteOf" and key != "isClusterOfHost"):
                     entity['toRelationships'][key] = []
-        
-        entity['tags'] = []
-        entity['properties'] = {}
+                    
+        if(type != 'HOST'):
+            
+            entity['tags'] = []
+            entity['properties'] = {}
 
         if (type in self.results['entities']):
             pass

--- a/flask-backend/src/process_match_settings_2_0.py
+++ b/flask-backend/src/process_match_settings_2_0.py
@@ -3,7 +3,6 @@ import settings_2_0
 import json
 import re
 import process_utils
-import process_analysis
 
 
 def match_config(run_info):
@@ -35,6 +34,7 @@ class LoadConfig(dict):
         self['multi_matched_schemas'] = {}
         self['key_not_found_schemas'] = {}
         self['multi_matched_objects'] = {}
+        self['multi_matched_key_id_object'] = {}
         self['management_zone_objects'] = {}
         self['configs'] = {}
         self['entities'] = {}
@@ -222,7 +222,13 @@ class LoadConfig(dict):
                 object_id)
 
             if (len(self[index_type][type][schema_id][entity_id][main_key_value]) > 1):
-                self['multi_matched_schemas'][schema_id] = True
+                print("Schema has multiple identical key_ids: ",
+                      schema_id, entity_id, main_key_value, object_id)
+                #self['multi_matched_schemas'][schema_id] = True
+                self['multi_matched_key_id_object'][object_id] = True
+                if (len(self[index_type][type][schema_id][entity_id][main_key_value]) == 2):
+                    previous_object_id = self[index_type][type][schema_id][entity_id][main_key_value][0]
+                    self['multi_matched_key_id_object'][previous_object_id] = True
 
     def add_config_entity_index(self, object_id, entity_id):
 

--- a/flask-backend/src/process_utils.py
+++ b/flask-backend/src/process_utils.py
@@ -54,7 +54,9 @@ def get_tenant_schemas_definitions_dict(run_info, is_target_tenant):
     return run_info['schemas_definitions_dict'][get_tenant_id(run_info, is_target_tenant)]
 
 
-def get_run_info(tenant_key_main, tenant_key_target, context_params=None, entity_filter=None, time_from=None, time_to=None, use_environment_cache=None, forced_schema_id=None, forced_key_id=None):
+def get_run_info(tenant_key_main, tenant_key_target, context_params=None, entity_filter=None, time_from=None, time_to=None, 
+                 use_environment_cache=None, forced_schema_id=None, forced_key_id=None,
+                 forced_keep_action_only=None):
     run_info = {}
 
     run_info = set_run_tags(
@@ -65,6 +67,7 @@ def get_run_info(tenant_key_main, tenant_key_target, context_params=None, entity
     run_info['tenant_key_target'] = tenant_key_target
     run_info = set_analysis_filter(
         run_info, entity_filter, time_from, time_to, use_environment_cache, forced_schema_id, forced_key_id)
+    run_info['forced_keep_action_only'] = forced_keep_action_only
 
     return run_info
 
@@ -127,6 +130,17 @@ def add_aggregate_error(run_info, error):
 
     run_info['aggregate_error'].append(str(error))
 
+
+def is_filtered_out_action(run_info, action):
+    if(run_info['forced_keep_action_only'] is None):
+        return False
+    
+    if(action in run_info['forced_keep_action_only']):
+        if(run_info['forced_keep_action_only'][action] == True):
+            return False
+    
+    return True
+        
 
 def get_tenant_param_dict(tenant_key_main, tenant_key_target, run_info, context_params=None):
 

--- a/flask-backend/src/route_migrate_v2.py
+++ b/flask-backend/src/route_migrate_v2.py
@@ -20,12 +20,15 @@ def migrate_settings_2_0():
     active_rules = flask_utils.get_arg_json('active_rules')
     forced_schema_id = flask_utils.get_arg('forced_schema_id')
     forced_key_id = flask_utils.get_arg('forced_key_id')
+    forced_keep_action_only = flask_utils.get_arg_json('forced_keep_action_only')
     context_params = flask_utils.get_arg_json('context_params')
-    use_environment_cache = flask_utils.get_arg_bool('use_environment_cache', False)
+    use_environment_cache = flask_utils.get_arg_bool(
+        'use_environment_cache', False)
     pre_migration = flask_utils.get_arg_bool('pre_migration', True)
 
     run_info = process_utils.get_run_info(
-        tenant_key_main, tenant_key_target, context_params, entity_filter, use_environment_cache=use_environment_cache, forced_schema_id=forced_schema_id, forced_key_id=forced_key_id)
+        tenant_key_main, tenant_key_target, context_params, entity_filter, use_environment_cache=use_environment_cache,
+        forced_schema_id=forced_schema_id, forced_key_id=forced_key_id, forced_keep_action_only=forced_keep_action_only)
 
     def call_process():
         result = process_migrate_config.migrate_config(
@@ -45,7 +48,8 @@ def migrate_ui_api_entity():
                                              process_utils.ALL_BASIC_ENTITY_LIST)
     active_rules = flask_utils.get_arg_json('active_rules')
     context_params = flask_utils.get_arg_json('context_params')
-    use_environment_cache = flask_utils.get_arg_bool('use_environment_cache', False)
+    use_environment_cache = flask_utils.get_arg_bool(
+        'use_environment_cache', False)
     pre_migration = flask_utils.get_arg_bool('pre_migration', True)
 
     run_info = process_utils.get_run_info(

--- a/react-frontend/src/backend/useEnhancedBackend.js
+++ b/react-frontend/src/backend/useEnhancedBackend.js
@@ -80,8 +80,6 @@ function useCompleteSearchParams(entityFilter, setEntityFilterApplyMigrationChec
 
                 if (entityFilter.forcedMatchChecked) {
 
-                    let isForcedMatch = false
-
                     if (entityFilter.forcedMatchEntityChecked === true
                         && entityFilter.forcedMatchMain
                         && entityFilter.forcedMatchMain !== ""
@@ -98,36 +96,38 @@ function useCompleteSearchParams(entityFilter, setEntityFilterApplyMigrationChec
                             }
                         })
 
-                        isForcedMatch = true
-                    }
-
-                    if (entityFilter.forcedMatchSchemaIdChecked === true
-                        && entityFilter.forcedMatchSchemaId) {
-
-                        completedSearchParams['forced_schema_id'] = entityFilter.forcedMatchSchemaId
-
-                        isForcedMatch = true
-                    }
-
-                    if (entityFilter.forcedMatchKeyIdChecked
-                        && entityFilter.forcedMatchKeyId) {
-
-                        completedSearchParams['forced_key_id'] = entityFilter.forcedMatchKeyId
-
-                        isForcedMatch = true
-                    }
-
-                    if (isForcedMatch) {
                         completedSearchParams['use_environment_cache'] = entityFilter.useEnvironmentCache
                     }
+                }
 
+                if (entityFilter.forcedMatchSchemaIdChecked === true
+                    && entityFilter.forcedMatchSchemaId) {
+
+                    completedSearchParams['forced_schema_id'] = entityFilter.forcedMatchSchemaId
+                }
+
+                if (entityFilter.forcedMatchKeyIdChecked
+                    && entityFilter.forcedMatchKeyId) {
+
+                    completedSearchParams['forced_key_id'] = entityFilter.forcedMatchKeyId
+                }
+
+                if (entityFilter.forcedKeepActionChecked) {
+                    const forcedKeepAction = {}
+                    console.log(entityFilter)
+                    forcedKeepAction['Add'] = entityFilter.forcedKeepAddChecked
+                    forcedKeepAction['Delete'] = entityFilter.forcedKeepDeleteChecked
+                    forcedKeepAction['Update'] = entityFilter.forcedKeepUpdateChecked
+                    forcedKeepAction['Identical'] = entityFilter.forcedKeepIdenticalChecked
+                    console.log(entityFilter.forcedKeepIdenticalChecked)
+                    completedSearchParams['forced_keep_action_only'] = JSON.stringify(forcedKeepAction)
                 }
 
                 if (entityFilter.applyMigrationChecked) {
-                    if(setEntityFilterApplyMigrationChecked) {
+                    if (setEntityFilterApplyMigrationChecked) {
                         setEntityFilterApplyMigrationChecked(false)
                     }
-                    if(setEntityFilterUseEnvironmentCache) {
+                    if (setEntityFilterUseEnvironmentCache) {
                         setEntityFilterUseEnvironmentCache(false)
                     }
                     completedSearchParams['pre_migration'] = false

--- a/react-frontend/src/context/EntityFilterContext.js
+++ b/react-frontend/src/context/EntityFilterContext.js
@@ -18,7 +18,12 @@ const attributes = {
     'forcedMatchSchemaId': {},
     'forcedMatchKeyIdChecked': { 'default': false },
     'forcedMatchKeyId': {},
-    'useEnvironmentCache': { 'default': true },
+    'forcedKeepActionChecked': { 'default': false },
+    'forcedKeepAddChecked': { 'default': true },
+    'forcedKeepDeleteChecked': { 'default': true },
+    'forcedKeepUpdateChecked': { 'default': true },
+    'forcedKeepIdenticalChecked': { 'default': true },
+    'useEnvironmentCache': { 'default': false },
     'applyMigrationChecked': { 'default': false },
 }
 

--- a/react-frontend/src/date/DateRangePicker.js
+++ b/react-frontend/src/date/DateRangePicker.js
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, Paper, TextField } from '@mui/material';
+import { Box, Checkbox, FormControlLabel, Paper, TextField } from '@mui/material';
 import * as React from 'react';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -62,11 +62,15 @@ export default function DateRangePicker({ label }) {
 
     return (
         <React.Fragment>
-            <LocalizationProvider dateAdapter={AdapterDayjs}>
-                <FormControlLabel control={<Checkbox checked={entityFilter.dateRangeChecked}
-                    onChange={handleChangDateRangeChecked} />} label={label} />
-                {dateTimePickerComponents}
-            </LocalizationProvider>
+            <Box sx={{ mt: 1 }} border={1}>
+                <Box sx={{ mx: 2 }}>
+                    <LocalizationProvider dateAdapter={AdapterDayjs}>
+                        <FormControlLabel control={<Checkbox checked={entityFilter.dateRangeChecked}
+                            onChange={handleChangDateRangeChecked} />} label={label} />
+                        {dateTimePickerComponents}
+                    </LocalizationProvider>
+                </Box>
+            </Box>
         </React.Fragment>
     );
 }

--- a/react-frontend/src/filter/AddEntityFilterButton.js
+++ b/react-frontend/src/filter/AddEntityFilterButton.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import AddIcon from '@mui/icons-material/Add';
+import IconButton from '@mui/material/IconButton';
+import { Typography } from '@mui/material';
+import { TENANT_KEY_TYPE_MAIN, useEntityFilterKey, useEntityFilterList } from '../context/EntityFilterContext';
+
+export default function AddEntityFilterButton() {
+
+    const { addEntityFilter } = useEntityFilterList()
+    const { setEntityFilterKey } = useEntityFilterKey()
+    
+    const handleAddEntityFilter = () => {
+        const newEntityFilterId = addEntityFilter()
+        setEntityFilterKey(newEntityFilterId)
+    }
+
+    return (
+        <React.Fragment>
+            <IconButton onClick={handleAddEntityFilter}>
+                <AddIcon />
+                <Typography>New EntityFilter</Typography>
+            </IconButton>
+        </React.Fragment>
+    );
+}

--- a/react-frontend/src/filter/EntityFilterSection.js
+++ b/react-frontend/src/filter/EntityFilterSection.js
@@ -6,47 +6,15 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import { useEntityFilter, useEntityFilterKey } from '../context/EntityFilterContext';
 import EntityFilterNameInput from './EntityFilterNameInput';
 import ForcedMatchInput from './ForcedMatchInput';
+import AddEntityFilterButton from './AddEntityFilterButton';
+import { useFilterOnLabel } from './useFilterOnLabel';
+import FilterInput from './FilterInput';
 
 export default function EntityFilterSection() {
 
     const { entityFilterKey } = useEntityFilterKey()
     const { entityFilter } = useEntityFilter(entityFilterKey)
-
-    const accordionLabel = React.useMemo(() => {
-        let label = ""
-        let isFirstConcat = true
-
-        const concatList = [
-            {
-                'enabled': entityFilter.dateRangeChecked,
-                'label': "Date Range"
-            },
-            {
-                'enabled': entityFilter.forcedMatchChecked,
-                'label': "Forced Entity Match"
-            }
-        ]
-
-        for (const concat of concatList) {
-            if (concat['enabled']) {
-                if (isFirstConcat) {
-                    label += "Filtering on "
-                    isFirstConcat = false
-                } else {
-                    label += ","
-                }
-                label += " "
-                label += concat['label']
-            }
-        }
-
-        if (isFirstConcat) {
-            label = "Not Filtering"
-        } else {
-            label += " ( " + entityFilter.label + " )"
-        }
-        return label
-    }, [entityFilterKey, entityFilter.forcedMatchChecked, entityFilter.label, entityFilter.dateRangeChecked])
+    const accordionLabel = useFilterOnLabel(entityFilter)
 
     return (
         <React.Fragment>
@@ -59,8 +27,10 @@ export default function EntityFilterSection() {
                 </AccordionSummary>
                 <AccordionDetails>
                     <EntityFilterSelector />
+                    <AddEntityFilterButton />
                     <EntityFilterNameInput />
                     <DateRangePicker label={"Migration Date Range"} />
+                    <FilterInput label={"Filters"} />
                     <ForcedMatchInput label={"Forced Match Mapping"} />
                 </AccordionDetails>
             </Accordion>

--- a/react-frontend/src/filter/EntityFilterSelector.js
+++ b/react-frontend/src/filter/EntityFilterSelector.js
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
-import { useEntityFilter, useEntityFilterKey, useEntityFilterList } from '../context/EntityFilterContext';
-import { Box, Button, Paper } from '@mui/material';
+import { useEntityFilterKey, useEntityFilterList } from '../context/EntityFilterContext';
+import { MenuItem, Paper } from '@mui/material';
+import { getEntityFilterLabel } from './useFilterOnLabel';
 
 export default function EntityFilterSelector() {
 
     const { entityFilterKey, setEntityFilterKey } = useEntityFilterKey()
-    const { entityFilter } = useEntityFilter(entityFilterKey)
     const { entityFilterList } = useEntityFilterList()
 
     const handleChangeEntityFilterKey = React.useMemo(() => {
@@ -43,45 +42,18 @@ export default function EntityFilterSelector() {
         )
     }, [entityFilterKey, entityFilterItems, handleChangeEntityFilterKey])
 
-    const linkToEntityFilterUI = React.useMemo(() => {
-        if (entityFilter && entityFilter.url && entityFilter.url !== "") {
-            return (
-                <Box>
-                    <Button href={entityFilter ? entityFilter.url : ""} target="_blank" rel=" noopener noreferrer">
-                        Go To EntityFilter UI
-                    </Button>
-                </Box >
-            )
-        } else {
-            return null
-        }
-    }, [entityFilter])
-
     return (
         <Paper>
             <FormControl fullWidth>
                 <InputLabel id="entityFilter-select-label">EntityFilter</InputLabel>
                 {selector}
             </FormControl>
-            {linkToEntityFilterUI}
         </Paper>
     )
 }
 
 const genEntityFilterItem = (entityFilter) => {
-    let label = entityFilter.label
-    if (!label || label === "") {
-        label = "New EntityFilter"
-    }
-    let url = entityFilter.url
-
-    if (url && entityFilter.url !== "") {
-        url = " ( " + url + " ) "
-    } else {
-        url = ""
-    }
-    label = entityFilter.key + ": " + label + url
     return (
-        <MenuItem value={entityFilter.key} key={"menuItem" + entityFilter.key}>{label}</MenuItem>
+        <MenuItem value={entityFilter.key} key={"menuItem" + entityFilter.key}>{getEntityFilterLabel(entityFilter)}</MenuItem>
     )
 }

--- a/react-frontend/src/filter/FilterInput.js
+++ b/react-frontend/src/filter/FilterInput.js
@@ -1,0 +1,140 @@
+import { Box, Checkbox, FormControl, FormControlLabel, FormLabel, Grid, Paper, TextField, Typography } from '@mui/material';
+import * as React from 'react';
+import { useEntityFilter, useEntityFilterKey } from '../context/EntityFilterContext';
+
+export default function FilterInput({ label }) {
+
+    const { entityFilterKey } = useEntityFilterKey()
+    const { entityFilter,
+        setEntityFilterForcedMatchSchemaIdChecked, setEntityFilterForcedMatchSchemaId,
+        setEntityFilterForcedMatchKeyIdChecked, setEntityFilterForcedMatchKeyId,
+        setEntityFilterForcedKeepActionChecked, setEntityFilterForcedKeepAddChecked,
+        setEntityFilterForcedKeepDeleteChecked, setEntityFilterForcedKeepUpdateChecked,
+        setEntityFilterForcedKeepIdenticalChecked,
+    } = useEntityFilter(entityFilterKey)
+
+    const forcedMatchComponents = React.useMemo(() => {
+
+        const handleChangeForcedMatchSchemaIdChecked = (event) => {
+            setEntityFilterForcedMatchSchemaIdChecked(event.target.checked)
+        }
+        const handleChangeForcedMatchSchemaId = (event) => {
+            setEntityFilterForcedMatchSchemaId(event.target.value)
+        }
+        const handleChangeForcedMatchKeyIdChecked = (event) => {
+            setEntityFilterForcedMatchKeyIdChecked(event.target.checked)
+        }
+        const handleChangeForcedMatchKeyId = (event) => {
+            setEntityFilterForcedMatchKeyId(event.target.value)
+        }
+        const handleChangeForcedKeepActionChecked = (event) => {
+            setEntityFilterForcedKeepActionChecked(event.target.checked)
+        }
+        const handleChangeForcedKeepAddChecked = (event) => {
+            setEntityFilterForcedKeepAddChecked(event.target.checked)
+        }
+        const handleChangeForcedKeepDeleteChecked = (event) => {
+            setEntityFilterForcedKeepDeleteChecked(event.target.checked)
+        }
+        const handleChangeForcedKeepUpdateChecked = (event) => {
+            setEntityFilterForcedKeepUpdateChecked(event.target.checked)
+        }
+        const handleChangeForcedKeepIdenticalChecked = (event) => {
+            setEntityFilterForcedKeepIdenticalChecked(event.target.checked)
+        }
+
+        let forcedKeepActionError = false
+        if (entityFilter.forcedKeepActionChecked) {
+            if (entityFilter.forcedKeepAddChecked
+                || entityFilter.forcedKeepDeleteChecked
+                || entityFilter.forcedKeepUpdateChecked
+                || entityFilter.forcedKeepIdenticalChecked) {
+
+            } else {
+                forcedKeepActionError = true
+            }
+        }
+
+        return (
+            <React.Fragment>
+                <Grid container>
+                    <Grid item xs={2}>
+                        <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchSchemaIdChecked} onChange={handleChangeForcedMatchSchemaIdChecked} />}
+                            label={"SchemaId:"} />
+                    </Grid>
+                    <Grid item xs={5}>
+                        <FormControl fullWidth>
+                            <TextField id="entity-filter-forced-match-main-text-field" variant="standard"
+                                label="Forced Match SchemaId" value={entityFilter.forcedMatchSchemaId} onChange={handleChangeForcedMatchSchemaId}
+                                disabled={!entityFilter.forcedMatchSchemaIdChecked} />
+                        </FormControl>
+                    </Grid>
+                </Grid>
+                <Grid container>
+                    <Grid item xs={2}>
+                        <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchKeyIdChecked} onChange={handleChangeForcedMatchKeyIdChecked} />}
+                            label={"keyId:"} />
+                    </Grid>
+                    <Grid item xs={5}>
+                        <FormControl fullWidth>
+                            <TextField id="entity-filter-forced-match-main-text-field" variant="standard"
+                                label="Forced Match KeyId" value={entityFilter.forcedMatchKeyId} onChange={handleChangeForcedMatchKeyId}
+                                disabled={!entityFilter.forcedMatchKeyIdChecked} />
+                        </FormControl>
+                    </Grid>
+                </Grid>
+                <FormControl fullWidth error = {forcedKeepActionError}>
+                    <Grid container>
+                        <Grid item xs={3}>
+                            <FormControlLabel control={<Checkbox checked={entityFilter.forcedKeepActionChecked} onChange={handleChangeForcedKeepActionChecked} />} />
+                            <FormLabel>Keep only checked config actions:</FormLabel>
+
+                        </Grid>
+                        <Grid item xs={5}>
+                            <Grid container>
+
+                                <Grid item xs={2}>
+                                    <FormControlLabel control={<Checkbox id="entity-filter-forcedKeepAddChecked" checked={entityFilter.forcedKeepAddChecked}
+                                        onChange={handleChangeForcedKeepAddChecked}
+                                        disabled={!entityFilter.forcedKeepActionChecked} />}
+                                        label={"Add"} />
+                                </Grid>
+                                <Grid item xs={2}>
+                                    <FormControlLabel control={<Checkbox id="entity-filter-forcedKeepDeleteChecked" checked={entityFilter.forcedKeepDeleteChecked}
+                                        onChange={handleChangeForcedKeepDeleteChecked}
+                                        disabled={!entityFilter.forcedKeepActionChecked} />}
+                                        label={"Delete"} />
+                                </Grid>
+                                <Grid item xs={2}>
+                                    <FormControlLabel control={<Checkbox id="entity-filter-forcedKeepUpdateChecked" checked={entityFilter.forcedKeepUpdateChecked}
+                                        onChange={handleChangeForcedKeepUpdateChecked}
+                                        disabled={!entityFilter.forcedKeepActionChecked} />}
+                                        label={"Update"} />
+                                </Grid>
+                                <Grid item xs={2}>
+                                    <FormControlLabel control={<Checkbox id="entity-filter-forcedKeepIdenticalChecked" checked={entityFilter.forcedKeepIdenticalChecked}
+                                        onChange={handleChangeForcedKeepIdenticalChecked}
+                                        disabled={!entityFilter.forcedKeepActionChecked} />}
+                                        label={"Identical"} />
+                                </Grid>
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                </FormControl>
+            </React.Fragment >
+        )
+    }, [entityFilter])
+
+    return (
+        <Box sx={{ mt: 1 }} border={1}>
+            <Box sx={{ mx: 2 }}>
+                <Paper>
+                    <Typography>{label}:</Typography>
+                    <Box>
+                        {forcedMatchComponents}
+                    </Box>
+                </Paper>
+            </Box>
+        </Box>
+    )
+}

--- a/react-frontend/src/filter/ForcedMatchInput.js
+++ b/react-frontend/src/filter/ForcedMatchInput.js
@@ -2,13 +2,11 @@ import { Box, Checkbox, FormControl, FormControlLabel, Grid, Paper, TextField } 
 import * as React from 'react';
 import { useEntityFilter, useEntityFilterKey } from '../context/EntityFilterContext';
 
-export default function ForcedMatchInput() {
+export default function ForcedMatchInput({ label }) {
 
     const { entityFilterKey } = useEntityFilterKey()
     const { entityFilter, setEntityFilterForcedMatchChecked,
         setEntityFilterForcedMatchEntityChecked, setEntityFilterForcedMatchMain, setEntityFilterForcedMatchTarget,
-        setEntityFilterForcedMatchSchemaIdChecked, setEntityFilterForcedMatchSchemaId,
-        setEntityFilterForcedMatchKeyIdChecked, setEntityFilterForcedMatchKeyId,
         setEntityFilterUseEnvironmentCache } = useEntityFilter(entityFilterKey)
 
     const handleChangForcedMatchChecked = (event) => {
@@ -26,27 +24,25 @@ export default function ForcedMatchInput() {
         const handleChangeForcedMatchTarget = (event) => {
             setEntityFilterForcedMatchTarget(event.target.value)
         }
-        const handleChangeForcedMatchSchemaIdChecked = (event) => {
-            setEntityFilterForcedMatchSchemaIdChecked(event.target.checked)
-        }
-        const handleChangeForcedMatchSchemaId = (event) => {
-            setEntityFilterForcedMatchSchemaId(event.target.value)
-        }
-        const handleChangeForcedMatchKeyIdChecked = (event) => {
-            setEntityFilterForcedMatchKeyIdChecked(event.target.checked)
-        }
-        const handleChangeForcedMatchKeyId = (event) => {
-            setEntityFilterForcedMatchKeyId(event.target.value)
-        }
         const handleChangeUseEnvironmentCache = (event) => {
             setEntityFilterUseEnvironmentCache(event.target.checked)
         }
 
         if (entityFilter.forcedMatchChecked) {
+
+            if (entityFilter.forcedKeepActionChecked) {
+                if (entityFilter.forcedKeepAddChecked
+                    || entityFilter.forcedKeepDeleteChecked
+                    || entityFilter.forcedKeepUpdateChecked
+                    || entityFilter.forcedKeepIdenticalChecked) {
+
+                } else {
+                    // show error label
+                }
+            }
+
             return (
                 <React.Fragment>
-                    <FormControlLabel control={<Checkbox checked={entityFilter.useEnvironmentCache} onChange={handleChangeUseEnvironmentCache} />}
-                        label={"Use Cached Global (environment) settings?"} />
                     <Grid container>
                         <Grid item xs={2}>
                             <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchEntityChecked} onChange={handleChangeForcedMatchEntityChecked} />}
@@ -67,32 +63,8 @@ export default function ForcedMatchInput() {
                             </FormControl>
                         </Grid>
                     </Grid>
-                    <Grid container>
-                        <Grid item xs={2}>
-                            <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchSchemaIdChecked} onChange={handleChangeForcedMatchSchemaIdChecked} />}
-                                label={"SchemaId:"} />
-                        </Grid>
-                        <Grid item xs={5}>
-                            <FormControl fullWidth>
-                                <TextField id="entity-filter-forced-match-main-text-field" variant="standard"
-                                    label="Forced Match SchemaId" value={entityFilter.forcedMatchSchemaId} onChange={handleChangeForcedMatchSchemaId}
-                                    disabled={!entityFilter.forcedMatchSchemaIdChecked} />
-                            </FormControl>
-                        </Grid>
-                    </Grid>
-                    <Grid container>
-                        <Grid item xs={2}>
-                            <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchKeyIdChecked} onChange={handleChangeForcedMatchKeyIdChecked} />}
-                                label={"keyId:"} />
-                        </Grid>
-                        <Grid item xs={5}>
-                            <FormControl fullWidth>
-                                <TextField id="entity-filter-forced-match-main-text-field" variant="standard"
-                                    label="Forced Match KeyId" value={entityFilter.forcedMatchKeyId} onChange={handleChangeForcedMatchKeyId}
-                                    disabled={!entityFilter.forcedMatchKeyIdChecked} />
-                            </FormControl>
-                        </Grid>
-                    </Grid>
+                    <FormControlLabel control={<Checkbox checked={entityFilter.useEnvironmentCache} onChange={handleChangeUseEnvironmentCache} />}
+                        label={"Use Cached Global (environment) settings?"} />
                 </React.Fragment >
             )
         } else {
@@ -101,12 +73,12 @@ export default function ForcedMatchInput() {
     }, [entityFilter])
 
     return (
-        <Box border={1}>
-            <Box sx={{ m: 2 }}>
-                <Paper sx={{ mt: 1 }}>
+        <Box sx={{ mt: 1 }} border={1}>
+            <Box sx={{ mx: 2 }}>
+                <Paper>
                     <Box>
                         <FormControlLabel control={<Checkbox checked={entityFilter.forcedMatchChecked}
-                            onChange={handleChangForcedMatchChecked} />} label={"Forced Match"} />
+                            onChange={handleChangForcedMatchChecked} />} label={label} />
                     </Box>
                     <Box>
                         {forcedMatchComponents}

--- a/react-frontend/src/filter/useFilterOnLabel.js
+++ b/react-frontend/src/filter/useFilterOnLabel.js
@@ -1,0 +1,67 @@
+import { useMemo } from "react"
+
+export const useFilterOnLabel = (entityFilter) => {
+
+    const label = useMemo(() => {
+        return genEntityFilterEnhancedLabel(entityFilter)
+
+    }, [entityFilter])
+
+    return label
+
+}
+
+export const genEntityFilterEnhancedLabel = (entityFilter) => {
+    let label = ""
+    let isFirstConcat = true
+
+    const concatList = [
+        {
+            'enabled': entityFilter.dateRangeChecked,
+            'label': "Date Range"
+        },
+        {
+            'enabled': entityFilter.forcedMatchSchemaIdChecked,
+            'label': "Schema Id"
+        },
+        {
+            'enabled': entityFilter.forcedMatchKeyIdChecked,
+            'label': "Key Id"
+        },
+        {
+            'enabled': entityFilter.forcedKeepActionChecked,
+            'label': "Actions"
+        },
+        {
+            'enabled': entityFilter.forcedMatchChecked,
+            'label': "Forced Entity Match"
+        },
+    ]
+
+    for (const concat of concatList) {
+        if (concat['enabled']) {
+            if (isFirstConcat) {
+                label += "Filtering on "
+                isFirstConcat = false
+            } else {
+                label += ","
+            }
+            label += " "
+            label += concat['label']
+        }
+    }
+
+    if (isFirstConcat) {
+        label = "Not Filtering"
+    }
+
+    return getEntityFilterLabel(entityFilter) + " ( " + label + " )"
+}
+
+export const getEntityFilterLabel = (entityFilter) => {
+    let label = entityFilter.label
+    if (!label || label === "") {
+        label = "New Entity Filter"
+    }
+    return label
+}

--- a/react-frontend/src/result/ResultDrawerDetails.js
+++ b/react-frontend/src/result/ResultDrawerDetails.js
@@ -139,6 +139,7 @@ export default function ResultDrawerDetails() {
 
                 const { from, to, schemaId } = keyValues
                 let keyId = null
+                const statusLabel = actionnableStatusMap[keyValues['status']]
 
                 let entityFilter = getDefaultEntityFilter()
                 entityFilter['forcedMatchChecked'] = true
@@ -147,7 +148,7 @@ export default function ResultDrawerDetails() {
                 entityFilter['forcedMatchTarget'] = to
                 entityFilter['forcedMatchSchemaIdChecked'] = true
                 entityFilter['forcedMatchSchemaId'] = schemaId
-
+                entityFilter['useEnvironmentCache'] = true
                 if ('key_id' in keyValues) {
                     entityFilter['forcedMatchKeyIdChecked'] = true
                     keyId = keyValues['key_id']
@@ -155,12 +156,17 @@ export default function ResultDrawerDetails() {
                 }
                 entityFilter['applyMigrationChecked'] = true
 
+                entityFilter['forcedKeepActionChecked'] = true
+                entityFilter.forcedKeepAddChecked = statusLabel === "Add"
+                entityFilter.forcedKeepDeleteChecked = statusLabel === "Delete"
+                entityFilter.forcedKeepUpdateChecked = statusLabel === "Update"
+                entityFilter.forcedKeepIdenticalChecked = statusLabel === "Identical"
+
                 let tempKeyId = keyId
                 if (keyId == null) {
                     tempKeyId = ""
                 }
 
-                const statusLabel = actionnableStatusMap[keyValues['status']]
 
                 disableButtonAfterCompletion = (data) => {
                     if (data == null) {


### PR DESCRIPTION
(Add only, Delete only, ...)
Add missing button to create multiple entity filters and keep them Allow migration of key_ids even if it's schema contains duplicate key_id some UI fixes
use env. cache only for forced entity matches