### PR TITLE
Fix: do not copy datasources file for multi-targeting

### DIFF
--- a/flask-backend/src/filter.py
+++ b/flask-backend/src/filter.py
@@ -11,7 +11,7 @@ class AnalysisFilter():
                                      'cloud:gcp:k8s_container', 'NETWORK_INTERFACE']
         '''
         self.entity_type_excluded = []
-        print("TODO: Review entity matching for performance, use sorted arrays, not maps, by then, we are excluding some entities from matching, excluded types are: ", self.entity_type_excluded)
+        #print("TODO: Review entity matching for performance, use sorted arrays, not maps, by then, we are excluding some entities from matching, excluded types are: ", self.entity_type_excluded)
 
         if (time_from is None
            or time_to is None):

--- a/flask-backend/src/terraform_cli_cmd.py
+++ b/flask-backend/src/terraform_cli_cmd.py
@@ -20,7 +20,6 @@ def gen_export_cmd_list(run_info, import_state):
         export_cmd_list.append("-import-state-v2")
     else:
         export_cmd_list.append("-migrate")
-        export_cmd_list.append("-datasources")
 
     if specific_schema_id != "":
         export_cmd_list.append(specific_schema_id)

--- a/flask-backend/src/terraform_local.py
+++ b/flask-backend/src/terraform_local.py
@@ -245,7 +245,12 @@ def plan_multi_target(run_info, tenant_key_main, tenant_key_target, terraform_pa
     path_config_modules = dirs.forward_slash_join(path_config, MODULES_DIR)
 
     copy_other_files(main_tf, path_modules, path_config_modules, PROVIDERS_FILES)
-    copy_other_files(main_tf, path_modules, path_config_modules, DATASOURCES_FILES)
+
+    # There shouldn't be datasources files as we use variables
+    # If there are at some point, then they should be handled properly
+    # Datasources create entries in the state files that also should be handled
+
+    # copy_other_files(main_tf, path_modules, path_config_modules, DATASOURCES_FILES)
     write_resources_tf_files(resources_tf_dict, path_modules)
     write_variables_tf_files(var_defs, path_modules)
     write_main_tf_file(main_tf, path)
@@ -560,7 +565,7 @@ def get_main_tf_definition(file_path, variable_list, module_dir):
                         (variable, variable_seasoned) = variable_info
                         if variable_seasoned in line:
                             current_module_details.append(line)
-                            #print(variable_seasoned, line)
+                            # print(variable_seasoned, line)
                             (
                                 variable_resource_module,
                                 variable_resource_name,

--- a/react-frontend/src/backend/backend.js
+++ b/react-frontend/src/backend/backend.js
@@ -31,17 +31,17 @@ export const TERRAFORM_LOAD_HISTORY_ITEM_LOG = 'terraform_load_history_item_log'
 export const TERRAFORM_OPEN_HISTORT_ITEM_LOG_VSCODE = 'terraform_open_history_log_in_vscode'
 
 
-export function backendGet(api_method, searchParams, thenFunction, catchFunction) {
+export function backendGet(api_method, searchParams, thenFunction, catchFunction, showAlert = true) {
 
     const requestOptions = {
         method: 'GET',
         mode: 'cors',
     }
 
-    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction)
+    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction, showAlert)
 }
 
-export function backendPost(api_method, payload, searchParams, thenFunction, catchFunction) {
+export function backendPost(api_method, payload, searchParams, thenFunction, catchFunction, showAlert = true) {
 
     const requestOptions = {
         method: 'POST',
@@ -50,10 +50,10 @@ export function backendPost(api_method, payload, searchParams, thenFunction, cat
         body: JSON.stringify(payload)
     }
 
-    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction)
+    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction, showAlert)
 }
 
-export function backendDelete(api_method, payload, searchParams, thenFunction, catchFunction) {
+export function backendDelete(api_method, payload, searchParams, thenFunction, catchFunction, showAlert = true) {
 
     const requestOptions = {
         method: 'DELETE',
@@ -62,10 +62,10 @@ export function backendDelete(api_method, payload, searchParams, thenFunction, c
         body: JSON.stringify(payload)
     }
 
-    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction)
+    return fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction, showAlert)
 }
 
-function fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction) {
+function fetchRunThen(api_method, requestOptions, searchParams, thenFunction, catchFunction, showAlert = true) {
     const fetchPromise = buildFetch(api_method, requestOptions, searchParams)
 
     if (thenFunction instanceof Function) {
@@ -73,7 +73,9 @@ function fetchRunThen(api_method, requestOptions, searchParams, thenFunction, ca
 
         return validationPromise
             .catch((error) => {
-                alert("Error Backend Api: " + api_method + "\n" + error)
+                if (showAlert) {
+                    alert("Error Backend Api: " + api_method + "\n" + error)
+                }
                 if (catchFunction instanceof Function) {
                     catchFunction(error)
                 }

--- a/react-frontend/src/credentials/TenantConfig.js
+++ b/react-frontend/src/credentials/TenantConfig.js
@@ -13,6 +13,8 @@ export const DEFAULT_MONACO_CONCURRENT_REQUESTS = 10
 
 export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
     const [envProxyURL, setEnvProxyUrl] = React.useState("")
+    const [tenantUrlError, setTenantUrlError] = React.useState(false)
+    const [tenantUrlErrorMessage, setTenantUrlErrorMessage] = React.useState("")
     const { tenantKey } = useTenantKey(tenantType)
     const {
         tenant, setTenantLabel, setTenantUrl, setTenantHeaders, setTenantAPIKey,
@@ -20,6 +22,7 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
         setTenantMonacoConcurrentRequests, setTenantDisableSSLVerification,
         setTenantDisableSystemProxies, setTenantProxyURL, setTenantNotes
     } = useTenant(tenantKey)
+
 
     const tenantUrlDisplay = React.useMemo(() => {
         if (!tenant.url || tenant.url === "") {
@@ -49,6 +52,36 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
                     })
         )
     }, [])
+
+    React.useEffect(() => {
+        let urlError = false;
+        let message = "";
+        console.log(tenant.url, typeof tenant.url)
+
+        if (tenant.url.endsWith("/")) {
+            // pass
+        } else {
+            urlError = true
+            message += "The URL should end with a slash '/'. "
+        }
+
+        if (tenant.url.includes(".live.dynatrace.com")) {
+            // pass
+        } else {
+            if (tenant.url.includes(".apps.dynatrace.com")) {
+                urlError = true
+                message += "Use the '.live' URL, not the '.apps' one. "
+            }
+        }
+
+        if (tenantUrlError !== urlError) {
+            setTenantUrlError(urlError)
+        }
+        if (tenantUrlErrorMessage !== message) {
+            setTenantUrlErrorMessage(message)
+        }
+
+    }, [tenant])
 
     /*
     const pasteHeaders = () => {
@@ -193,7 +226,7 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
     return (
         <Fragment>
             <Box sx={{ mt: 2 }}>
-                <Typography>Required credentials:</Typography>
+                <Typography>Credentials [Required]:</Typography>
                 <Box sx={{ ml: 2 }}>
                     <React.Fragment>
                         <FormControl fullWidth>
@@ -205,7 +238,8 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
                         <FormControl fullWidth>
                             <TextField id={"tenant-url-field" + tenantKey} variant="standard"
                                 label="Tenant Url (https://<YOUR_TENANT>.live.dynatrace.com/)" value={tenantUrlDisplay}
-                                onChange={handleChangeUrl} />
+                                onChange={handleChangeUrl}
+                                error={tenantUrlError} helperText={tenantUrlErrorMessage} />
                         </FormControl>
                     </React.Fragment>
                     <React.Fragment>
@@ -225,29 +259,11 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
                     <React.Fragment>
                         <TestConnectionButton tenantKey={tenantKey} />
                     </React.Fragment>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <TextField id={"tenant-monacoConcurrentRequests-field" + tenantKey}
-                                type="number"
-                                variant="standard"
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                                label="Number of Concurrent Requests for Monaco cli calls to tenant" value={tenantMonacoConcurrentRequests}
-                                onChange={handleChangeMonacoConcurrentRequests} />
-                        </FormControl>
-                    </React.Fragment>
                 </Box>
             </Box>
             <Box sx={{ mt: 2 }}>
-                <Typography>Optional Connection Options:</Typography>
+                <Typography>Connection Options [Optional]:</Typography>
                 <Box sx={{ ml: 2 }}>
-                    <React.Fragment>
-                        <FormControl fullWidth>
-                            <FormControlLabel control={<Checkbox checked={tenant.disableSSLVerification === true}
-                                onChange={handleChangeDisableSSLVerification} />} label={"Disable SSL Verification"} />
-                        </FormControl>
-                    </React.Fragment>
                     <React.Fragment>
                         <FormControl fullWidth>
                             <FormControlLabel control={<Checkbox checked={tenant.disableSystemProxies === true}
@@ -259,7 +275,7 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
                     <React.Fragment>
                         <FormControl fullWidth>
                             <TextField id={"proxyURL-text-field" + tenantKey} variant="standard"
-                                label={getProxyLabel(envProxyURL)} value={tenant.proxyURL} onChange={handleChangeProxyURL} disabled={tenant.disableSystemProxies}/>
+                                label={getProxyLabel(envProxyURL)} value={tenant.proxyURL} onChange={handleChangeProxyURL} disabled={tenant.disableSystemProxies} />
                         </FormControl>
                     </React.Fragment>
                     <React.Fragment>
@@ -275,6 +291,18 @@ export default function TenantConfig({ tenantType = TENANT_KEY_TYPE_MAIN }) {
             <Box sx={{ mt: 2 }}>
                 <Typography>Other:</Typography>
                 <Box sx={{ ml: 2 }}>
+                    <React.Fragment>
+                        <FormControl fullWidth>
+                            <TextField id={"tenant-monacoConcurrentRequests-field" + tenantKey}
+                                type="number"
+                                variant="standard"
+                                InputLabelProps={{
+                                    shrink: true,
+                                }}
+                                label="Number of Concurrent Requests for Monaco cli calls to tenant" value={tenantMonacoConcurrentRequests}
+                                onChange={handleChangeMonacoConcurrentRequests} />
+                        </FormControl>
+                    </React.Fragment>
                     <React.Fragment>
                         <FormControl fullWidth>
                             <TextField id={"notes-text-field" + tenantKey} variant="standard"
@@ -293,10 +321,20 @@ const getProxyLabel = (envProxyURL) => {
         label += " [Default: "
         label += envProxyURL
         label += "]"
-    }   
+    }
 
     return label
 }
+
+/*
+
+                    <React.Fragment>
+                        <FormControl fullWidth>
+                            <FormControlLabel control={<Checkbox checked={tenant.disableSSLVerification === true}
+                                onChange={handleChangeDisableSSLVerification} />} label={"Disable SSL Verification"} />
+                        </FormControl>
+                    </React.Fragment>
+*/
 
 
 /*

--- a/react-frontend/src/docum/DocumAPIToken.js
+++ b/react-frontend/src/docum/DocumAPIToken.js
@@ -39,21 +39,26 @@ const managedUrl =
 const expirationDateOneDay =
     `"now+1d"`
 const curlPartTwo =
-    `api/v2/apiTokens" -H "accept: application/json; charset=utf-8" -H "Content-Type: application/json; charset=utf-8" -d "{"name":"Dynatrace Config Manager (Write)", "expirationDate": ${expirationDateOneDay},"scopes":[`
+    `api/v2/apiTokens" -H "accept: application/json; charset=utf-8" -H "Content-Type: application/json; charset=utf-8" -d `
+const curlObjectStart =
+    `{"name":"Dynatrace Config Manager (Write)", "expirationDate": ${expirationDateOneDay},"scopes":[`
+const curlObjectEnd =
+    `]}`
 const urlSuffix =
-    `]}" -H "Authorization: Api-Token XXXXXXXX"`
+    ` -H "Authorization: Api-Token XXXXXXXX"`
 const readTokenValue =
     `"entities.read","networkZones.read","settings.read","slo.read","credentialVault.read","DataExport","ReadConfig"`
 const writeTokenValue =
     `"networkZones.write","settings.write","slo.write","CaptureRequestData","credentialVault.write","ExternalSyntheticIntegration","WriteConfig"`
 
+const curlReadObject = JSON.stringify(`${curlObjectStart}${readTokenValue}${curlObjectEnd}`)
 
 const curlRead =
     `
 curl for SaaS tenant:
-${curlPrefix}${saasUrl}${curlPartTwo}${readTokenValue}${urlSuffix}
+${curlPrefix}${saasUrl}${curlPartTwo}${curlReadObject}${urlSuffix}
 Curl for Managed tenant:
-${curlPrefix}${managedUrl}${curlPartTwo}${readTokenValue}${urlSuffix}
+${curlPrefix}${managedUrl}${curlPartTwo}${curlReadObject}${urlSuffix}
 `
 
 const writeScopeSection =
@@ -70,12 +75,15 @@ Write Scopes (in addition to the read scopes):
 
 `
 
+
+const curlWriteObject = JSON.stringify(`${curlObjectStart}${readTokenValue},${writeTokenValue}${curlObjectEnd}`)
+
 const curlWrite =
     `
 curl for SaaS tenant:
-${curlPrefix}${saasUrl}${curlPartTwo}${readTokenValue},${writeTokenValue}${urlSuffix}
+${curlPrefix}${saasUrl}${curlPartTwo}${curlWriteObject}${urlSuffix}
 Curl for Managed tenant:
-${curlPrefix}${managedUrl}${curlPartTwo}${readTokenValue},${writeTokenValue}${urlSuffix}
+${curlPrefix}${managedUrl}${curlPartTwo}${curlWriteObject}${urlSuffix}
 `
 
 export default function DocumAPIToken() {

--- a/react-frontend/src/result/ResultDrawerDetailsSchema.js
+++ b/react-frontend/src/result/ResultDrawerDetailsSchema.js
@@ -194,7 +194,7 @@ export default function ResultDrawerDetailsSchema({ contextNode, setContextNode,
                 </IconButton>
                 <Typography sx={{ ml: 2, mb: 1 }}>Row: {rowIdx} of: {rowLength}</Typography>
                 {rowLabelList}
-                <ResultDrawerList key={"DrawerList" + keyValues['module']} result={result} contextNode={contextNode} setContextNode={setContextNode} />
+                <ResultDrawerList key={"DrawerList" + keyValues['module'] + contextNode.searchText} result={result} contextNode={contextNode} setContextNode={setContextNode} />
             </React.Fragment>
         )
 


### PR DESCRIPTION
Features:
Remove unused options in the credentials menu
Auto-test connection
Fixes:
Remove old Print in flask
Remove -datasources in export hcl (although it still creates datasource) Do not copy datasources for multi-targeting
Write the curl commands properly
Uncheck drawer list when changing search text